### PR TITLE
added enabled and silent audio flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Main node for generating audio from video and text.
 - **sample_nums**: Number of audio samples to generate (1-6, default: 1)
 - **seed**: Random seed for reproducibility (INT)
 - **model_path**: Path to pretrained models (optional, leave empty for auto-download)
+- **enabled**: Enable or disable the entire node. If disabled, it will pass through a silent or null audio output without processing. (BOOLEAN, default: True)
+- **silent_audio**: Controls the output when the node is disabled or fails. If true, it outputs a silent audio clip. If false, it outputs `None`. (BOOLEAN, default: True)
 
 **Outputs:**
 - **video_with_audio**: Video with generated audio merged (VIDEO)


### PR DESCRIPTION
This pull request introduces two quality-of-life features to the main generator nodes (`HunyuanVideoFoleyNode` and `HunyuanVideoFoleyGeneratorAdvanced`) to improve workflow flexibility and robustness.

#### 1. Added `enabled` Toggle

*   **What it does:** Adds a boolean `enabled` checkbox (defaulting to `True`) to the node's inputs.
*   **Why it's useful:** Allows users to programmatically bypass the node's execution without needing to disconnect it from the workflow. When disabled, the node short-circuits and immediately returns a null or silent output, making it ideal for automation and complex branching workflows.

#### 2. Added `silent_audio` Toggle

*   **What it does:** Adds a boolean `silent_audio` checkbox (defaulting to `True`) that controls the node's output behavior in two scenarios:
    1.  When the node is disabled via the `enabled` flag.
    2.  When any exception occurs during the generation process.
*   **Why it's useful:**
    *   If `silent_audio` is `True` (default), the node returns a valid, silent audio dictionary. This ensures compatibility with downstream nodes like VHS Video Combine that expect a valid audio object.
    *   If `silent_audio` is `False`, the node returns `None`. This is useful for workflows that need to explicitly check for a null output to trigger different logic paths.

#### Implementation Details:

*   The core logic, including a new `try...except` block for robust error handling, has been added to the base `HunyuanVideoFoleyNode`.
*   The `HunyuanVideoFoleyGeneratorAdvanced` node has been updated to correctly inherit and pass these new arguments, ensuring consistent behavior across both generator nodes.

These changes make the node more resilient to errors, preventing a failure in audio generation from halting an entire long-running workflow, and provide greater control for users building automated systems.